### PR TITLE
Stream to accelerator

### DIFF
--- a/apps/hardware_benchmarks/apps/gaussian/gaussian_generator.cpp
+++ b/apps/hardware_benchmarks/apps/gaussian/gaussian_generator.cpp
@@ -28,9 +28,9 @@ public:
         RDom win(0, blockSize, 0, blockSize);
 
         Func hw_input, input_copy;
-        //hw_input(x, y) = cast<uint16_t>(input(x, y));
-        input_copy(x, y) = cast<uint16_t>(input(x, y));
-        hw_input(x, y) = input_copy(x, y);
+        hw_input(x, y) = cast<uint16_t>(input(x, y));
+        //input_copy(x, y) = cast<uint16_t>(input(x, y));
+        //hw_input(x, y) = input_copy(x, y);
 
         // create the gaussian kernel
         Func kernel_f;
@@ -115,9 +115,12 @@ public:
           blur_unnormalized.compute_at(hw_output, xo);
           blur.compute_at(hw_output, xo);
 
-          hw_input.compute_at(hw_output, xo);
-          hw_input.stream_to_accelerator();
-          input_copy.compute_root();
+          hw_input.stream_to_accelerator();//.compute_root();//at(output, xo);
+          //hw_input.compute_root();
+          
+          //hw_input.compute_at(hw_output, xo);
+          //input_copy.stream_to_accelerator();
+          //input_copy.compute_root();
           
         } else {    // schedule to CPU
 

--- a/apps/hardware_benchmarks/hw_support/hardware_targets.mk
+++ b/apps/hardware_benchmarks/hw_support/hardware_targets.mk
@@ -240,7 +240,7 @@ endif
 # we should remake process in case there are extra dependencies
 .PHONY: $(BIN)/process
 $(BIN)/process: $(PROCESS_DEPS)
-	echo coreir=$(WITH_COREIR) cpu=$(WITH_CPU) clockwork=$(WITH_CLOCKWORK)
+	@echo coreir=$(WITH_COREIR) cpu=$(WITH_CPU) clockwork=$(WITH_CLOCKWORK)
 	@-mkdir -p $(BIN)
 	@#env LD_LIBRARY_PATH=$(COREIR_DIR)/lib $(CXX) $(CXXFLAGS) -I$(BIN) -I$(HWSUPPORT) -I$(HWSUPPORT)/xilinx_hls_lib_2015_4 -Wall $(HLS_PROCESS_CXX_FLAGS)  -O3 $^ -o $@ $(LDFLAGS) $(IMAGE_IO_FLAGS)
 	@#$(CXX) $(CXXFLAGS) -I$(BIN) -I$(HWSUPPORT) -I$(HWSUPPORT)/xilinx_hls_lib_2015_4 -Wall $(HLS_PROCESS_CXX_FLAGS)  -O3 $^ -o $@ $(LDFLAGS) $(IMAGE_IO_FLAGS)

--- a/src/CodeGen_RDAI.cpp
+++ b/src/CodeGen_RDAI.cpp
@@ -24,6 +24,13 @@ public:
 
     vector<HW_Arg> arguments(const Scope<HW_Stencil_Type>& streams_scope) {
         vector<HW_Arg> result;
+        if (!buffers.empty()) {
+          std::cout << "buffers include: ";
+          for (auto buffer : buffers) {
+            std::cout << buffer.first << ", ";
+          }
+          std::cout << std::endl;
+        }
         internal_assert(buffers.empty()) << "we expect no references to buffers in a hardware pipeline\n";
         for(const pair<string, Type> &v : vars) {
             if(ends_with(v.first, ".stencil")) {
@@ -38,7 +45,7 @@ public:
                 result.push_back({v.first, false, true, v.second, HW_Stencil_Type()});
             }
         }
-        result.push_back({"hw_output_stencil", true, true, Type(), streams_scope.get("hw_output.stencil")});
+        result.push_back({output_name + "_stencil", true, true, Type(), streams_scope.get("hw_output.stencil")});
         return result;
     }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2604,10 +2604,24 @@ Func &Func::hw_accelerate(Var compute_var, Var store_var) {
     return *this;
 }
 
-Func &Func::stream_to_accelerator() {
-  //func.schedule().accelerate_inputs().insert(hw_in.name());
+// Set this as an accelerator input. This will be converted into a stencil
+// to count as a valid input into a hardware accelerator.
+Func &Func::accelerator_input() {
   func.schedule().is_accelerator_input() = true;
   return *this;
+}
+
+// Set this as an accelerator input, create a copy stage, and properly
+// schedule each func. The accelerator input is computed at the root level.
+// The copy stage is computed at the accelerator storage level.
+Func Func::stream_to_accelerator() {
+  //invalidate_cache();
+  //func.schedule().accelerate_inputs().insert(hw_in.name());
+  func.schedule().is_accelerator_input() = true;
+  func.schedule().compute_level() = LoopLevel::root();
+
+  auto new_func = get_wrapper(func, name() + "_global_wrapper", {}, false);
+  return new_func;
 }
   
 Func &Func::linebuffer() {

--- a/src/Func.h
+++ b/src/Func.h
@@ -2240,7 +2240,9 @@ public:
                             std::vector<Func> taps = {});
     
     Func &hw_accelerate(Var compute_var, Var store_var);
-    Func &stream_to_accelerator();
+
+    Func &accelerator_input();
+    Func stream_to_accelerator();
 
     /** Schedule a function to be linebuffered.
      */

--- a/src/HWBufferRename.cpp
+++ b/src/HWBufferRename.cpp
@@ -5,6 +5,7 @@
 #include "Simplify.h"
 #include "Substitute.h"
 
+using std::map;
 using std::string;
 using std::vector;
 
@@ -66,24 +67,44 @@ public:
 
 
 class RenameStencilRealizes : public IRMutator {
+  const map<string, Function> &env;
+  bool in_xcel;
+  
     using IRMutator::visit;
 
     Stmt visit(const Realize *op) override {
-      if (false) {//if (op->name == "curve") {
-        return IRMutator::visit(op);
+      auto func = env.at(op->name);
+      if (in_xcel || func.schedule().is_accelerator_input()) {
+        string realize_name = op->name + ".stencil";
+        Stmt new_body = RenameRealize(op->name, realize_name).mutate(op->body);
+        new_body = mutate(new_body);
+        return Realize::make(realize_name, op->types, op->memory_type,
+                             op->bounds, op->condition, new_body);
+        
+      } else {
+
+        if (!func.schedule().is_accelerated()) {
+          return IRMutator::visit(op);
+        }
+      
+        string realize_name = op->name + ".stencil";
+        Stmt new_body = RenameRealize(op->name, realize_name).mutate(op->body);
+
+        in_xcel = true;
+        new_body = mutate(new_body);
+        in_xcel = false;
+        
+        return Realize::make(realize_name, op->types, op->memory_type,
+                             op->bounds, op->condition, new_body);
       }
-      string realize_name = op->name + ".stencil";
-      Stmt new_body = RenameRealize(op->name, realize_name).mutate(op->body);
-      new_body = mutate(new_body);
-      return Realize::make(realize_name, op->types, op->memory_type,
-                           op->bounds, op->condition, new_body);
     }
+
 public:
-    RenameStencilRealizes() { }
+  RenameStencilRealizes(const map<string, Function> &env) : env(env), in_xcel(false){ }
 };
 
-Stmt rename_hwbuffers(Stmt s) {
-    auto renamed = RenameStencilRealizes().mutate(s);
+Stmt rename_hwbuffers(Stmt s, const map<string, Function> &env) {
+    auto renamed = RenameStencilRealizes(env).mutate(s);
     return renamed;
 }
 

--- a/src/HWBufferRename.h
+++ b/src/HWBufferRename.h
@@ -11,7 +11,7 @@
 namespace Halide {
 namespace Internal {
 
-Stmt rename_hwbuffers(Stmt s);
+Stmt rename_hwbuffers(Stmt s, const std::map<std::string, Function> &env);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -328,7 +328,7 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     //std::cout << "Before storage flattening...\n" << s << "\n\n";
 
     if (t.has_feature(Target::Clockwork)) {
-      s = rename_hwbuffers(s);
+      s = rename_hwbuffers(s, env);
     }
     
     s = storage_flattening(s, outputs, env, t);
@@ -489,7 +489,7 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     } else {
         debug(1) << "Skipping Hexagon offload...\n";
     }
-    //std::cout << "after passes: " << s << std::endl;
+    std::cout << "after passes: " << s << std::endl;
 
     if (!custom_passes.empty()) {
         for (size_t i = 0; i < custom_passes.size(); i++) {


### PR DESCRIPTION
- accelerator input properly checked as a boundary to hardware accelerator
- accelerate_input to accelerate_output used as boundaries to Funcs that are converted to _stencils
- added new accelerate_input() scheduling primitive that defines an accelerator input
- modified stream_to_accelerator as syntatic sugar for accelerate_input, create copy stage, schedule Func as compute_root, and schedule copy stage as compute_accelerate_store_level