### PR TITLE
quick fix for coreir namespace issue

### DIFF
--- a/src/CoreIRCompute.cpp
+++ b/src/CoreIRCompute.cpp
@@ -137,7 +137,9 @@ void connect_wires(CoreIR::ModuleDef *def, vector<CoreIR::Wireable*> in_wires, v
 
 map<string, string> coreir_generators(CoreIR::Context* context) {
   // set up coreir generation
-  map<string, string> gens;
+  static map<string, string> gens;
+
+  if(!gens.empty()) return gens;
 
   // add all generators from coreirprims
   context->getNamespace("coreir");


### PR DESCRIPTION
This is a quick workaround for our coreir namespace collision issue. It seems coreir doesn't allow us to load the same libs more than once. To solve this, I just memoized the gens map so that we don't have to repopulate it (hence we won't load libraries more than once)