### PR TITLE
Modify metadata generation script and source code

### DIFF
--- a/apps/hardware_benchmarks/hw_support/parse_design_meta.py
+++ b/apps/hardware_benchmarks/hw_support/parse_design_meta.py
@@ -21,6 +21,7 @@ def parseArguments():
     return args
 
 def findBetween(s:str, start:str, end:str):
+    end = end if "clkwrk" in s else "_op_hcompute"
     assert (start in s) and (end in s)
     starti = s.find(start) + len(start)
     endi = s.find(end, starti)
@@ -41,7 +42,7 @@ def setOrCheck(json, key, value):
 
 def parseDesignTop(meta, filename: str):
     meta["testing"]["coreir"] = filename
-    
+
     with open(filename, "r") as readFile:
         designTop = json.load(readFile)
         topName = designTop["top"]
@@ -75,8 +76,7 @@ def parseDesignTop(meta, filename: str):
 def parseDesignPlace(meta, filename: str):
     print("parsing design place", filename)
     meta["testing"]["placement"] = filename
-    meta["testing"]["bitstream"] = filename.replace("place", "bs")
-    
+
     with open(filename, "r") as readFile:
         lines = readFile.readlines()
         for line in lines:
@@ -89,7 +89,7 @@ def parseDesignPlace(meta, filename: str):
                 tileOut = findIO(metaOut["io_tiles"], name)
                 setOrCheck(tileOut, "x_pos", int(words[1]))
                 setOrCheck(tileOut, "y_pos", int(words[2]))
-                
+
             elif ("\t#I" in line) and name.startswith("io16in_"):
                 assert len(words) == 4
                 ioName = findBetween(name, "io16in_", "_clkwrk")
@@ -113,17 +113,25 @@ def main():
 
     with open(args.DesignMeta, "r") as designMeta:
         meta = json.load(designMeta)
+
+        # Search for *.bs file in the bin directory
+        bin_directory = args.DesignMeta.replace("/design_meta_halide.json", "");
+        for file in os.listdir(f"{bin_directory}"):
+            if file.endswith(".bs"):
+                meta["testing"]["bitstream"] = f"bin/{file}"
+                break
+
         if args.top != None:
             parseDesignTop(meta, args.top)
-                    
+
         if args.place != None:
             parseDesignPlace(meta, args.place)
 
     outputName = 'bin/design_meta.json'
     with open(outputName, 'w', encoding='utf-8') as fileout:
-        pprint.pprint(meta, fileout, indent=2, compact=True)
+        # pprint.pprint(meta, fileout, indent=2, compact=True)
         print("writing to", outputName)
-        #json.dump(meta, fileout, indent=2)
+        json.dump(meta, fileout, indent=2)
 
 if __name__ == "__main__":
     main()

--- a/apps/hardware_benchmarks/hw_support/parse_design_meta.py
+++ b/apps/hardware_benchmarks/hw_support/parse_design_meta.py
@@ -41,7 +41,7 @@ def setOrCheck(json, key, value):
         json[key] = value
 
 def parseDesignTop(meta, filename: str):
-    meta["testing"]["coreir"] = filename
+    meta["testing"]["coreir"] = os.path.basename(filename)
 
     with open(filename, "r") as readFile:
         designTop = json.load(readFile)

--- a/apps/hardware_benchmarks/hw_support/parse_design_meta.py
+++ b/apps/hardware_benchmarks/hw_support/parse_design_meta.py
@@ -116,9 +116,9 @@ def main():
 
         # Search for *.bs file in the bin directory
         bin_directory = args.DesignMeta.replace("/design_meta_halide.json", "");
-        for file in os.listdir(f"{bin_directory}"):
+        for file in os.listdir(bin_directory):
             if file.endswith(".bs"):
-                meta["testing"]["bitstream"] = f"bin/{file}"
+                meta["testing"]["bitstream"] = file
                 break
 
         if args.top != None:

--- a/src/CodeGen_Clockwork_Target.cpp
+++ b/src/CodeGen_Clockwork_Target.cpp
@@ -955,8 +955,11 @@ void print_clockwork_execution_cpp(string appname, const map<string,vector<HW_Ar
       string datafile = output_name + ".raw";
       design_meta["IOs"]["outputs"] = { io_info({output_name, bitwidth, shape, datafile}) };
 
-      design_meta["testing"]["interleaved_input"] = "bin/input.pgm";
-      design_meta["testing"]["interleaved_output"] = "bin/gold.pgm";
+      vector<string> input_names, output_names;
+      input_names.emplace_back("bin/input.pgm");
+      output_names.emplace_back("bin/gold.pgm");
+      design_meta["testing"]["interleaved_input"] = input_names;
+      design_meta["testing"]["interleaved_output"] = output_names;
 
       string design_meta_filename = "bin/design_meta_halide.json";
       ofstream design_meta_file(design_meta_filename.c_str());

--- a/src/CodeGen_Clockwork_Target.cpp
+++ b/src/CodeGen_Clockwork_Target.cpp
@@ -956,8 +956,8 @@ void print_clockwork_execution_cpp(string appname, const map<string,vector<HW_Ar
       design_meta["IOs"]["outputs"] = { io_info({output_name, bitwidth, shape, datafile}) };
 
       vector<string> input_names, output_names;
-      input_names.emplace_back("bin/input.pgm");
-      output_names.emplace_back("bin/gold.pgm");
+      input_names.emplace_back("input.pgm");
+      output_names.emplace_back("gold.pgm");
       design_meta["testing"]["interleaved_input"] = input_names;
       design_meta["testing"]["interleaved_output"] = output_names;
 


### PR DESCRIPTION
This PR has these changes

**`parse_design_meta.py`**
1. Use `json_dump` instead of `pprint` to follow the `json` format
2. `*.bs` is not saved in the same directory as `.place` file. Instead, search for `*.bs` in the `bin` directory.
3.  Remove `bin/` from the `testing` fields.
4. Add fix to `clkwrk` assertion error

**`CodeGen_Clockwork_Target.cpp`**
1. Store `interleaved_input/output` as a vector of string, instead of just string.