### PR TITLE
Restoring make-mem and make-test-mem

### DIFF
--- a/apps/hardware_benchmarks/hw_support/hardware_targets.mk
+++ b/apps/hardware_benchmarks/hw_support/hardware_targets.mk
@@ -180,7 +180,8 @@ $(BIN)/optimized_$(TESTNAME).cpp opt-clockwork clockwork-opt opt: $(BIN)/clockwo
 	./clockwork_codegen opt 1>mem_cout 2> >(tee -a mem_cout >&2); \
 	EXIT_CODE=$$?; cd ..; exit $$EXIT_CODE
 
-compile_mem compile-mem mem-clockwork clockwork-mem $(BIN)/map_result/$(TESTNAME)/$(TESTNAME).json: $(BIN)/clockwork_codegen 
+compile_mem compile-mem mem-clockwork clockwork-mem $(BIN)/map_result/$(TESTNAME)/$(TESTNAME).json: $(BIN)/clockwork_codegen
+	@mkdir -p $(BIN)/coreir_compute && cp $(BIN)/$(TESTNAME)_compute.json $(BIN)/coreir_compute/$(TESTNAME)_compute.json
 	cd $(BIN) && \
 	CLKWRK_PATH=$(CLOCKWORK_PATH) LD_LIBRARY_PATH=$(CLOCKWORK_PATH)/lib:$(COREIR_DIR)/lib LAKE_PATH=$(LAKE_PATH) LAKE_CONTROLLERS=$(abspath $(BIN)) LAKE_STREAM=$(BIN) COREIR_PATH=$(COREIR_DIR) \
 	./clockwork_codegen compile_mem 1>mem_cout 2> >(tee -a mem_cout >&2); \
@@ -211,7 +212,7 @@ reschedule_mem:
 	python $(HWSUPPORT)/copy_clockwork_schedules.py $(BIN)/map_result/$(TESTNAME)/$(TESTNAME)_to_metamapper.json $(BIN)/design_top.json $(BIN)/$(TESTNAME)_flush_latencies.json $(BIN)/$(TESTNAME)_pond_latencies.json
 
 mem design_top design_top.json $(BIN)/design_top.json: $(BIN)/map_result/$(TESTNAME)/$(TESTNAME).json
-	cp $(BIN)/map_result/$(TESTNAME)/$(TESTNAME)_to_metamapper.json $(BIN)/design_top.json
+	cp $(BIN)/map_result/$(TESTNAME)/$(TESTNAME)_garnet.json $(BIN)/design_top.json
 
 map: $(BIN)/clockwork_codegen
 	make tree

--- a/apps/hardware_benchmarks/hw_support/hardware_targets.mk
+++ b/apps/hardware_benchmarks/hw_support/hardware_targets.mk
@@ -16,6 +16,7 @@ GOLDEN ?= golden
 HWSUPPORT ?= ../../hw_support
 FUNCUBUF_PATH ?= $(abspath $(ROOT_DIR)/../../../..)
 LAKE_PATH ?= $(abspath $(CLOCKWORK_DIR)/../lake)
+METAMAPPER_PATH ?= $(abspath $(CLOCKWORK_DIR)/../MetaMapper)
 LDFLAGS += -lcoreir-lakelib
 
 #WITH_CLOCKWORK ?= 0
@@ -179,8 +180,7 @@ $(BIN)/optimized_$(TESTNAME).cpp opt-clockwork clockwork-opt opt: $(BIN)/clockwo
 	./clockwork_codegen opt 1>mem_cout 2> >(tee -a mem_cout >&2); \
 	EXIT_CODE=$$?; cd ..; exit $$EXIT_CODE
 
-compile_mem compile-mem mem-clockwork clockwork-mem $(BIN)/map_result/$(TESTNAME)/$(TESTNAME).json: $(BIN)/clockwork_codegen $(BIN)/$(TESTNAME)_compute_mapped.json
-	cp /aha/MetaMapper/libs/*_header.json $(BIN)/ && cp /aha/MetaMapper/libs/*_header.json /aha/clockwork/ && cp /aha/MetaMapper/libs/*_header.json /aha/garnet/headers/
+compile_mem compile-mem mem-clockwork clockwork-mem $(BIN)/map_result/$(TESTNAME)/$(TESTNAME).json: $(BIN)/clockwork_codegen 
 	cd $(BIN) && \
 	CLKWRK_PATH=$(CLOCKWORK_PATH) LD_LIBRARY_PATH=$(CLOCKWORK_PATH)/lib:$(COREIR_DIR)/lib LAKE_PATH=$(LAKE_PATH) LAKE_CONTROLLERS=$(abspath $(BIN)) LAKE_STREAM=$(BIN) COREIR_PATH=$(COREIR_DIR) \
 	./clockwork_codegen compile_mem 1>mem_cout 2> >(tee -a mem_cout >&2); \
@@ -213,10 +213,16 @@ reschedule_mem:
 mem design_top design_top.json $(BIN)/design_top.json: $(BIN)/map_result/$(TESTNAME)/$(TESTNAME).json
 	cp $(BIN)/map_result/$(TESTNAME)/$(TESTNAME)_to_metamapper.json $(BIN)/design_top.json
 
-map $(BIN)/$(TESTNAME)_compute_mapped.json: $(BIN)/$(TESTNAME)_compute.json
+map: $(BIN)/clockwork_codegen
 	make tree
-	python /aha/MetaMapper/scripts/map_$(META_TARGET).py $(BIN)/$(TESTNAME)_compute.json $(PIPELINED)
+	python $(METAMAPPER_PATH)/scripts/map_$(META_TARGET).py $(BIN)/$(TESTNAME)_compute.json $(PIPELINED)
 	sed -i -e 's/_mapped//g' $(BIN)/$(TESTNAME)_compute_mapped.json
+	cp $(METAMAPPER_PATH)/libs/*_header.json $(BIN)/ && cp $(METAMAPPER_PATH)/libs/*_header.json $(CLOCKWORK_PATH)/ && cp $(METAMAPPER_PATH)/libs/*_header.json $(METAMAPPER_PATH)/../garnet/headers/ 
+	cd $(BIN) && \
+	CLKWRK_PATH=$(CLOCKWORK_PATH) LD_LIBRARY_PATH=$(CLOCKWORK_PATH)/lib:$(COREIR_DIR)/lib LAKE_PATH=$(LAKE_PATH) LAKE_CONTROLLERS=$(abspath $(BIN)) LAKE_STREAM=$(BIN) COREIR_PATH=$(COREIR_DIR) \
+	./clockwork_codegen compile_mem_use_metamapper 1>mem_cout 2> >(tee -a mem_cout >&2); \
+	EXIT_CODE=$$?; rm unoptimized_$(TESTNAME)*; cd ..; exit $$EXIT_CODE
+	cp $(BIN)/map_result/$(TESTNAME)/$(TESTNAME)_to_metamapper.json $(BIN)/design_top.json
 
 #FIXME: $(BIN)/unoptimized_$(TESTNAME).o
 $(BIN)/clockwork_testscript.o: $(BIN)/clockwork_testscript.cpp $(UNOPTIMIZED_OBJS) $(BIN)/unoptimized_$(TESTNAME).o

--- a/src/CodeGen_Clockwork_Target.cpp
+++ b/src/CodeGen_Clockwork_Target.cpp
@@ -667,7 +667,7 @@ void print_clockwork_codegen(string appname, vector<string> xcels, ofstream& str
          << "        // Run Memory Mapper and dump collateral into dir" << endl
          << "        string dir = \"./map_result\";" << endl
          << std::boolalpha
-         << "        compile_app_for_garnet_single_port_mem(prg, dir, true, " << enable_ponds << ");" << endl
+         << "        compile_app_for_garnet_single_port_mem(prg, dir, true, " << enable_ponds << ", false);" << endl
          << endl
          << "      } else if (args[i] == \"compile_and_test_mem\") {" << endl
          << "        preprocess_prog(prg);" << endl
@@ -677,13 +677,39 @@ void print_clockwork_codegen(string appname, vector<string> xcels, ofstream& str
          << endl
          << "        // Run Memory Mapper and dump collateral into dir" << endl
          << "        string dir = \"./map_result\";" << endl
-         << "        compile_app_for_garnet_single_port_mem(prg, dir, /*gen_config_only=*/false, /*enable_ponds=*/" << enable_ponds << ");" << endl
+         << "        compile_app_for_garnet_single_port_mem(prg, dir, /*gen_config_only=*/false, /*enable_ponds=*/" << enable_ponds << ", /*use_metamapper*/false);" << endl
+         << endl
+         << "        // Run interconnect agnostic tb" << endl
+         << "        auto cgra = cgra_flow_result(prg, dir);" << endl
+         << endl
+         << "        sanity_check(prg, cpu, cgra);" << endl
+         << "      } else if (args[i] == \"compile_mem_use_metamapper\") {" << endl
+         << "        preprocess_prog(prg);" << endl
+         << endl
+         << "        // Run Frontend Test, generate gold TB" << endl
+         << "        auto cpu = unoptimized_result(prg);" << endl
+         << endl
+         << "        // Run Memory Mapper and dump collateral into dir" << endl
+         << "        string dir = \"./map_result\";" << endl
+         << std::boolalpha
+         << "        compile_app_for_garnet_single_port_mem(prg, dir, true, " << enable_ponds << ", true);" << endl
+         << endl
+         << "      } else if (args[i] == \"compile_and_test_mem_use_metamapper\") {" << endl
+         << "        preprocess_prog(prg);" << endl
+         << endl
+         << "        // Run Frontend Test, generate gold TB" << endl
+         << "        auto cpu = unoptimized_result(prg);" << endl
+         << endl
+         << "        // Run Memory Mapper and dump collateral into dir" << endl
+         << "        string dir = \"./map_result\";" << endl
+         << "        compile_app_for_garnet_single_port_mem(prg, dir, /*gen_config_only=*/false, /*enable_ponds=*/" << enable_ponds << ", /*use_metamapper*/true);" << endl
          << endl
          << "        // Run interconnect agnostic tb" << endl
          << "        auto cgra = cgra_flow_result(prg, dir);" << endl
          << endl
          << "        sanity_check(prg, cpu, cgra);" << endl
          << "      }" << endl
+
          << "      i += 1;" << endl
          << "    }" << endl
          << "  }" << endl

--- a/src/CodeGen_Clockwork_Target.cpp
+++ b/src/CodeGen_Clockwork_Target.cpp
@@ -705,7 +705,7 @@ void print_clockwork_codegen(string appname, vector<string> xcels, ofstream& str
          << "        compile_app_for_garnet_single_port_mem(prg, dir, /*gen_config_only=*/false, /*enable_ponds=*/" << enable_ponds << ", /*use_metamapper*/true);" << endl
          << endl
          << "        // Run interconnect agnostic tb" << endl
-         << "        auto cgra = cgra_flow_result(prg, dir);" << endl
+         << "        auto cgra = aha_flow_result(prg, dir);" << endl
          << endl
          << "        sanity_check(prg, cpu, cgra);" << endl
          << "      }" << endl


### PR DESCRIPTION
These changes restore the original behavior of make compile_mem, make-mem, and make test-mem. I've added all of the clockwork and metamapper mapping to the make map command. This is temporary, when I have some time I will move the calls to metamapper and clockwork to within the aha flow.

This requires the latest commit of the new_lake branch of clockwork. 